### PR TITLE
Added priority, datetime, and consistent R | P lettering

### DIFF
--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -66,6 +66,7 @@ export class EventsController {
     @Param('id', MongoIdPipe) id: string,
     @Body() registerAttendeeDto: RegisterAttendeeDto,
   ) {
+    const priority = false; //add function here
     const { status, message } = await this.eventsService.registerAttendance(
       id,
       registerAttendeeDto.id,
@@ -75,6 +76,6 @@ export class EventsController {
       throw new HttpException(message, status);
     }
 
-    return { status, message };
+    return { status, message, priority };
   }
 }

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -73,6 +73,9 @@ export class WalletService {
             },
           ],
         },
+        dateTime: {
+          end: "2023-09-17T23:59:59.52Z"
+        },
         detailsTemplateOverride: {
           detailsItemInfos: [
             {
@@ -120,7 +123,7 @@ export class WalletService {
             contentDescription: {
               defaultValue: {
                 language: 'en-US',
-                value: 'R|P 2023 Banner',
+                value: 'R | P 2023 Banner',
               },
             },
           },
@@ -129,8 +132,8 @@ export class WalletService {
       ],
       textModulesData: [
         {
-          header: 'Make connections at R|P 2023',
-          body: "Attend conferences, make connections, and learn about technology at Reflections|Projections '23.",
+          header: 'Make connections at R | P 2023',
+          body: "Attend conferences, make connections, and learn about technology at Reflections | Projections '23.",
           id: 'event_overview',
         },
       ],
@@ -138,7 +141,7 @@ export class WalletService {
         uris: [
           {
             uri: 'https://www.reflectionsprojections.org/',
-            description: "Official R|P '23 Site",
+            description: "Official R | P '23 Site",
             id: 'official_site',
           },
         ],
@@ -204,7 +207,7 @@ export class WalletService {
       cardTitle: {
         defaultValue: {
           language: 'en',
-          value: 'Reflections|Projections 2023',
+          value: 'Reflections | Projections 2023',
         },
       },
       subheader: {
@@ -226,7 +229,7 @@ export class WalletService {
       },
       heroImage: {
         sourceUri: {
-          uri: 'https://i.imgur.com/noyESjM.png',
+          uri: 'https://i.imgur.com/dk8svPp.png',
         },
       },
       textModulesData: [


### PR DESCRIPTION
Made **R | P** branding consistent with the style guide, added a `datetime` parameter for the Google Pass for expiration, and added a `priority` tag for attendee priority status (to be implemented later)